### PR TITLE
closeDriver if bad input item

### DIFF
--- a/PBL/View/addItemView.py
+++ b/PBL/View/addItemView.py
@@ -94,6 +94,7 @@ class AddItemView(tk.Frame):
         self.menuOptions = dropdown_options
 
         if not dropdown_options:
+            self.controller.closeDriver()
             self.displayErrorMessage()
 
         else:
@@ -115,7 +116,7 @@ class AddItemView(tk.Frame):
             else:
                 self.add_button['state'] = tk.DISABLED
 
-        self.controller.closeDriver()
+            self.controller.closeDriver()
 
 
     def addItem(self):


### PR DESCRIPTION
Forgot to push this last change. It closes the selenium driver if an invalid item was submitted in the add item form.

A bad item is an item that cannot meet the 2000¥ minimum value.

i.e: maximum quantity is 3 but the item price is 500¥. Maximum value is 1500¥.